### PR TITLE
Bugfix: RCTTVView patches

### DIFF
--- a/React/Views/RCTTVView.m
+++ b/React/Views/RCTTVView.m
@@ -228,7 +228,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:unused)
 {
   _hasTVPreferredFocus = hasTVPreferredFocus;
   if (hasTVPreferredFocus) {
-    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(1.0 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+    dispatch_async(dispatch_get_main_queue(), ^{
       UIView *rootview = self;
       while (![rootview isReactRootView] && rootview != nil) {
         rootview = [rootview superview];
@@ -237,6 +237,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:unused)
 
       rootview = [rootview superview];
 
+      [(RCTRootView *)rootview setReactPreferredFocusedView:self];
       [rootview setNeedsFocusUpdate];
       [rootview updateFocusIfNeeded];
     });


### PR DESCRIPTION
## Summary

In version 0.59 somehow the `[(RCTRootView *)rootview setReactPreferredFocusedView:self];` line was removed. This caused broke the behaviour of setting the focus to a view.

We are working on an app, and the delay caused all sorts of weird behaviour. We patched this in our version and it's working. I made a PR to the core repo at the time, but nobody knew why the delay was there. And in the end it didn't get merged.

## Changelog

* Fixed broken functionality when you try to set the `hasTVPreferredFocus` through `nativeProps` or `updateView`
* Removed delay in `setHasTVPreferredFocus`

## Test Plan

We have this code running in our app. And for us it's working out.