### PR TITLE
Fix react-native init template files for tvOS

### DIFF
--- a/template/App.js
+++ b/template/App.js
@@ -13,7 +13,6 @@ import {
   ScrollView,
   View,
   Text,
-  StatusBar,
 } from 'react-native';
 
 import {
@@ -27,7 +26,6 @@ import {
 const App = () => {
   return (
     <Fragment>
-      <StatusBar barStyle="dark-content" />
       <SafeAreaView>
         <ScrollView
           contentInsetAdjustmentBehavior="automatic"

--- a/template/ios/Podfile
+++ b/template/ios/Podfile
@@ -1,13 +1,12 @@
-platform :ios, '9.0'
+platform :tvos, '12.0'
 require_relative '../node_modules/@react-native-community/cli-platform-ios/native_modules'
 
-target 'HelloWorld' do
+target 'HelloWorld-tvOS' do
   # Pods for HelloWorld
   pod 'React', :path => '../node_modules/react-native/'
   pod 'React-Core', :path => '../node_modules/react-native/React'
   pod 'React-DevSupport', :path => '../node_modules/react-native/React'
   pod 'React-fishhook', :path => '../node_modules/react-native/Libraries/fishhook'
-  pod 'React-RCTActionSheet', :path => '../node_modules/react-native/Libraries/ActionSheetIOS'
   pod 'React-RCTAnimation', :path => '../node_modules/react-native/Libraries/NativeAnimation'
   pod 'React-RCTBlob', :path => '../node_modules/react-native/Libraries/Blob'
   pod 'React-RCTImage', :path => '../node_modules/react-native/Libraries/Image'
@@ -15,7 +14,6 @@ target 'HelloWorld' do
   pod 'React-RCTNetwork', :path => '../node_modules/react-native/Libraries/Network'
   pod 'React-RCTSettings', :path => '../node_modules/react-native/Libraries/Settings'
   pod 'React-RCTText', :path => '../node_modules/react-native/Libraries/Text'
-  pod 'React-RCTVibration', :path => '../node_modules/react-native/Libraries/Vibration'
   pod 'React-RCTWebSocket', :path => '../node_modules/react-native/Libraries/WebSocket'
 
   pod 'React-cxxreact', :path => '../node_modules/react-native/ReactCommon/cxxreact'
@@ -28,20 +26,11 @@ target 'HelloWorld' do
   pod 'glog', :podspec => '../node_modules/react-native/third-party-podspecs/glog.podspec'
   pod 'Folly', :podspec => '../node_modules/react-native/third-party-podspecs/Folly.podspec'
 
-  target 'HelloWorldTests' do
-    inherit! :search_paths
-    # Pods for testing
-  end
-
   use_native_modules!
-end
-
-target 'HelloWorld-tvOS' do
-  # Pods for HelloWorld-tvOS
-
   target 'HelloWorld-tvOSTests' do
     inherit! :search_paths
     # Pods for testing
   end
 
 end
+

--- a/template/package.json
+++ b/template/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "react": "16.8.6",
-    "react-native": "0.60.4"
+    "react-native": "npm:react-native-tvos@0.60.4-1"
   },
   "devDependencies": {
     "@babel/core": "^7.5.0",


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

Fix issue #5 (react-native init project doesn't compile for tvOS in 0.60.4-1.  In 0.60, projects created with `react-native init` use Cocoapods, and the template files were not adjusted appropriately.

The changes in this PR allow the `-tvOS` target to compile.  They have the effect of breaking the iOS target.  I will be working on a way to support both targets in the template file, but don't yet have a clean solution for that.

## Test Plan

Tested this locally and the changes look good.  Will test against the tvos-v0.60.4 branch before doing a patch release.
