### PR TITLE
Update to the readme to help direct other developers to the tvOS branch. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Going forward, Apple TV support for React Native will be maintained here and in the corresponding `react-native-tvos` NPM package, and not in the [core repo](https://github.com/facebook/react-native/).  This is a full fork of the main repository, with only the changes needed to support Apple TV.
 
+This is a test.
+
 Releases of `react-native-tvos` will be based on a public release of `react-native`; e.g. the 0.60.4-1 release of this package will be derived from the 0.60.4 release of `react-native`.
 
 To build your project for Apple TV, you should change your `package.json` imports to import `react-native` as follows, so that this package is used.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Going forward, Apple TV support for React Native will be maintained here and in 
 
 Releases of `react-native-tvos` will be based on a public release of `react-native`; e.g. the 0.60.4-1 release of this package will be derived from the 0.60.4 release of `react-native`.
 
-You will find the relevant tvOS support and maintence within the branches marked 'tvOS';   
+You will find the relevant tvOS support and maintence within the branches marked 'tvos';   
 
 To build your project for Apple TV, you should change your `package.json` imports to import `react-native` as follows, so that this package is used.
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ Going forward, Apple TV support for React Native will be maintained here and in 
 
 Releases of `react-native-tvos` will be based on a public release of `react-native`; e.g. the 0.60.4-1 release of this package will be derived from the 0.60.4 release of `react-native`.
 
+You will find the relevant tvOS support and maintence within the branches marked 'tvOS';   
+
 To build your project for Apple TV, you should change your `package.json` imports to import `react-native` as follows, so that this package is used.
 
 ```js

--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 Going forward, Apple TV support for React Native will be maintained here and in the corresponding `react-native-tvos` NPM package, and not in the [core repo](https://github.com/facebook/react-native/).  This is a full fork of the main repository, with only the changes needed to support Apple TV.
 
-This is a test.
-
 Releases of `react-native-tvos` will be based on a public release of `react-native`; e.g. the 0.60.4-1 release of this package will be derived from the 0.60.4 release of `react-native`.
 
 To build your project for Apple TV, you should change your `package.json` imports to import `react-native` as follows, so that this package is used.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Going forward, Apple TV support for React Native will be maintained here and in 
 
 Releases of `react-native-tvos` will be based on a public release of `react-native`; e.g. the 0.60.4-1 release of this package will be derived from the 0.60.4 release of `react-native`.
 
-You will find the relevant tvOS support and maintence within the branches marked 'tvos';   
+You will find the relevant tvOS support and maintence within the branches marked `tvos`;   
 
 To build your project for Apple TV, you should change your `package.json` imports to import `react-native` as follows, so that this package is used.
 


### PR DESCRIPTION
## Summary

The motivation for this small change was to help other developers like me avoid confusion when reading the documentation. I did not realize that the master branch was not up to date with the most recent tvOS changes. For example I was looking to test a tvOS sample on the RNTester app. I wanted to verify the TVMenuControl behaved as I needed. But I had mistakenly tested the RNTester app within the master branch which did not have the TVMenuControl module. I realized shortly after that I needed to install the RNTester app that was within the tvos-v0.60.4 branch. 

Thanks for maintaining this repo <3. 
