### PR TITLE
Quick fix for dictation cutoff in tvOS TextInput component

### DIFF
--- a/Libraries/Text/TextInput/RCTBaseTextInputView.m
+++ b/Libraries/Text/TextInput/RCTBaseTextInputView.m
@@ -115,6 +115,10 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithFrame:(CGRect)frame)
     self.backedTextInputView.isSecureTextEntry ||
     fontHasBeenUpdatedBySystem;
 
+#if TARGET_OS_TV
+  shouldFallbackToBareTextComparison = YES;
+#endif
+
   if (shouldFallbackToBareTextComparison) {
     return ([newText.string isEqualToString:oldText.string]);
   } else {


### PR DESCRIPTION
## Summary

Issues with dictation cutoff on iOS were fixed in React Native core in https://github.com/facebook/react-native/pull/19687 and https://github.com/facebook/react-native/pull/18456.

However, these fixes don't work for tvOS.  Best solution for now is to add to the fixes from the above PRs a new condition, where tvOS always tests for the underlying string equality not the attributed string equality.

## Test Plan

Tested with a real tvOS 13.3 device.
