### PR TITLE
Refactor RCTTVView's event sender and animation to support subclassing

### DIFF
--- a/React/Views/RCTTVView.h
+++ b/React/Views/RCTTVView.h
@@ -28,4 +28,29 @@
  */
 @property (nonatomic, assign) BOOL hasTVPreferredFocus;
 
+/**
+ * Send Focus Notifications to listeners
+ */
+- (void)sendFocusNotification:(UIFocusUpdateContext *)context;
+
+/**
+ * Send Blur Notifications to listeners
+ */
+- (void)sendBlurNotification:(UIFocusUpdateContext *)context;
+
+/**
+ * Send Select Notification to listeners
+ */
+- (void)sendSelectNotification:(UIGestureRecognizer *)recognizer;
+
+/**
+ * Adds Parallax Motion Effects if tvParallaxProperty is enabled
+ */ 
+- (void)addParallaxMotionEffects;
+
+/**
+ * Removes Parallax Motion Effects if tvParallaxProperty is enabled
+ */
+- (void)removeParallaxMotionEffects;
+
 @end

--- a/React/Views/RCTTVView.m
+++ b/React/Views/RCTTVView.m
@@ -105,15 +105,19 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:unused)
             self.transform = CGAffineTransformMakeScale(magnification, magnification);
           }
           completion:^(__unused BOOL finished2) {
-            [[NSNotificationCenter defaultCenter] postNotificationName:RCTTVNavigationEventNotification 
-              object:@{@"eventType":@"select",@"tag":self.reactTag}];
+            [self sendSelectNotification:r];
           }];
        }];
     
 	} else {
-		[[NSNotificationCenter defaultCenter] postNotificationName:RCTTVNavigationEventNotification
-															                          object:@{@"eventType":@"select",@"tag":self.reactTag}];
+		[self sendSelectNotification:r];
 	}
+}
+
+- (void)sendSelectNotification:(__unused UIGestureRecognizer *)recognizer
+{
+  [[NSNotificationCenter defaultCenter] postNotificationName:RCTTVNavigationEventNotification
+  object:@{@"eventType":@"select",@"tag":self.reactTag}];
 }
 
 - (BOOL)isUserInteractionEnabled
@@ -128,6 +132,10 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:unused)
 
 - (void)addParallaxMotionEffects
 {
+  if(![self.tvParallaxProperties[@"enabled"] boolValue]) {
+    return;
+  }
+
   // Size of shift movements
   CGFloat const shiftDistanceX = [self.tvParallaxProperties[@"shiftDistanceX"] floatValue];
   CGFloat const shiftDistanceY = [self.tvParallaxProperties[@"shiftDistanceY"] floatValue];
@@ -197,6 +205,21 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:unused)
   }];
 }
 
+- (void)removeParallaxMotionEffects
+{
+  [UIView animateWithDuration:0.2 animations:^{
+    float magnification = [self.tvParallaxProperties[@"magnification"] floatValue];
+    BOOL enabled = [self.tvParallaxProperties[@"enabled"] boolValue];
+    if (enabled && magnification) {
+      self.transform = CGAffineTransformScale(self.transform, 1.0/magnification, 1.0/magnification);
+    }
+  }];
+
+  for (UIMotionEffect *effect in [self.motionEffects copy]){
+    [self removeMotionEffect:effect];
+  }
+}
+
 - (void)didUpdateFocusInContext:(UIFocusUpdateContext *)context withAnimationCoordinator:(UIFocusAnimationCoordinator *)coordinator
 {
   if (context.previouslyFocusedView == context.nextFocusedView) {
@@ -205,30 +228,28 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:unused)
   if (context.nextFocusedView == self && self.isTVSelectable ) {
     [self becomeFirstResponder];
     [coordinator addCoordinatedAnimations:^(void){
-      if([self.tvParallaxProperties[@"enabled"] boolValue]) {
-        [self addParallaxMotionEffects];
-      }
-      [[NSNotificationCenter defaultCenter] postNotificationName:RCTTVNavigationEventNotification
-                                                          object:@{@"eventType":@"focus",@"tag":self.reactTag}];
+      [self addParallaxMotionEffects];
+      [self sendFocusNotification:context];
     } completion:^(void){}];
   } else {
     [coordinator addCoordinatedAnimations:^(void){
-      [[NSNotificationCenter defaultCenter] postNotificationName:RCTTVNavigationEventNotification
-                                                          object:@{@"eventType":@"blur",@"tag":self.reactTag}];
-      [UIView animateWithDuration:0.2 animations:^{
-          float magnification = [self.tvParallaxProperties[@"magnification"] floatValue];
-          BOOL enabled = [self.tvParallaxProperties[@"enabled"] boolValue];
-          if (enabled && magnification) {
-            self.transform = CGAffineTransformScale(self.transform, 1.0/magnification, 1.0/magnification);
-          }
-      }];
-
-      for (UIMotionEffect *effect in [self.motionEffects copy]){
-        [self removeMotionEffect:effect];
-      }
+      [self sendBlurNotification:context];
+      [self removeParallaxMotionEffects];
     } completion:^(void){}];
     [self resignFirstResponder];
   }
+}
+
+- (void)sendFocusNotification:(__unused UIFocusUpdateContext *)context
+{
+  [[NSNotificationCenter defaultCenter] postNotificationName:RCTTVNavigationEventNotification
+  object:@{@"eventType":@"focus",@"tag":self.reactTag}];
+}
+
+- (void)sendBlurNotification:(__unused UIFocusUpdateContext *)context
+{
+  [[NSNotificationCenter defaultCenter] postNotificationName:RCTTVNavigationEventNotification
+  object:@{@"eventType":@"blur",@"tag":self.reactTag}];
 }
 
 - (void)setHasTVPreferredFocus:(BOOL)hasTVPreferredFocus

--- a/React/Views/RCTTVView.m
+++ b/React/Views/RCTTVView.m
@@ -22,6 +22,7 @@
 @implementation RCTTVView
 {
   UITapGestureRecognizer *_selectRecognizer;
+  BOOL motionEffectsAdded;
 }
 
 - (instancetype)initWithFrame:(CGRect)frame
@@ -40,6 +41,7 @@
       };
     });
     self.tvParallaxProperties = defaultTVParallaxProperties;
+    motionEffectsAdded = NO;
   }
 
   return self;
@@ -136,6 +138,10 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:unused)
     return;
   }
 
+  if(motionEffectsAdded == YES) {
+    return;
+  }
+
   // Size of shift movements
   CGFloat const shiftDistanceX = [self.tvParallaxProperties[@"shiftDistanceX"] floatValue];
   CGFloat const shiftDistanceY = [self.tvParallaxProperties[@"shiftDistanceY"] floatValue];
@@ -203,10 +209,16 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:unused)
   [UIView animateWithDuration:0.2 animations:^{
     self.transform = CGAffineTransformScale(self.transform, magnification, magnification);
   }];
+
+  motionEffectsAdded = YES;
 }
 
 - (void)removeParallaxMotionEffects
 {
+  if(motionEffectsAdded == NO) {
+    return;
+  }
+
   [UIView animateWithDuration:0.2 animations:^{
     float magnification = [self.tvParallaxProperties[@"magnification"] floatValue];
     BOOL enabled = [self.tvParallaxProperties[@"enabled"] boolValue];
@@ -218,6 +230,8 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:unused)
   for (UIMotionEffect *effect in [self.motionEffects copy]){
     [self removeMotionEffect:effect];
   }
+
+  motionEffectsAdded = NO;
 }
 
 - (void)didUpdateFocusInContext:(UIFocusUpdateContext *)context withAnimationCoordinator:(UIFocusAnimationCoordinator *)coordinator


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

**The motivation behind the refactor of focus, blur, & select events**
Currently, select, focus, blur events for a view are broadcasted via TVRemoteHandler Module, which I have experienced to be a major source of frame drops in our app when the number of touchable elements on the screen increases. I have instead subclassed RCTTVView in our app which uses RCTDirectEventBlock to send events to the view.

**The motivation behind the refactors of parallax animation.**
In our app, there are scenarios where the blur event of a touchable element is not called to remove the parallax effects but instead, another focus event is called thereby adding another parallax effect in addition to the already existing one. thereby increasing the size of the touchable element from normal.
To fix this, in our app, we subclassed RCTTVView and added a flag that checks if the parallax effect has already been added therefore need not add it again. 

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/facebook/react-native/wiki/Changelog for an example. -->

[tvOS] [Added] - Refactor RCTTVView's event sender and animation to support subclassing

## Test Plan
NA
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
