### PR TITLE
TVFocusGuideView improvements for 0.62.2

### DIFF
--- a/Libraries/Components/AppleTV/TVFocusGuideView.js
+++ b/Libraries/Components/AppleTV/TVFocusGuideView.js
@@ -41,10 +41,15 @@ class TVFocusGuideView extends React.Component<FocusGuideProps> {
   render() {
     if (Platform.isTVOS) {
       return (
-        <RNFocusGuide
-          ref={ref => (this._focusGuideRef = ref)}
-          destinationTags={this._destinationTags}
-        />
+        // Container view must have nonzero size
+        <ReactNative.View style={[{minHeight: 1, minWidth: 1}, this.props.style]}>
+          <RNFocusGuide
+            ref={ref => (this._focusGuideRef = ref)}
+            destinationTags={this._destinationTags}
+          >
+            {this.props.children}
+          </RNFocusGuide>
+        </ReactNative.View>
       );
     }
     return <React.Fragment />;

--- a/Libraries/Components/AppleTV/TVFocusGuideView.js
+++ b/Libraries/Components/AppleTV/TVFocusGuideView.js
@@ -44,6 +44,7 @@ class TVFocusGuideView extends React.Component<FocusGuideProps> {
         // Container view must have nonzero size
         <ReactNative.View style={[{minHeight: 1, minWidth: 1}, this.props.style]}>
           <RNFocusGuide
+            style={this.props.style}
             ref={ref => (this._focusGuideRef = ref)}
             destinationTags={this._destinationTags}
           >

--- a/RNTester/js/examples/TVFocusGuide/TVFocusGuideExample.js
+++ b/RNTester/js/examples/TVFocusGuide/TVFocusGuideExample.js
@@ -57,6 +57,8 @@ class TVFocusGuideExample extends React.Component<
 
   buttonBottomLeft: ?Object;
 
+  rightButtonInFocusViewContainer: ?Object;
+
   _setDestination(destination: ?Object, destinationText: string) {
     this.setState({
       destination,
@@ -102,9 +104,36 @@ class TVFocusGuideExample extends React.Component<
               height,
             }}>
             <Text style={styles.buttonText}>
-              Focus guide points to {this.state.destinationText}
+              Pink focus guide points to {this.state.destinationText}
             </Text>
           </View>
+          <TVFocusGuideView style={styles.containerFocusGuide} destinations={[this.rightButtonInFocusViewContainer]}>
+            <TouchableOpacity
+              onPress={() => {}}
+              style={{
+                width,
+                height,
+              }}>
+              <Text style={styles.buttonText}>Wrapped button 1</Text>
+            </TouchableOpacity>
+            <TouchableOpacity
+              onPress={() => {}}
+              style={{
+                width,
+                height,
+              }}>
+              <Text style={styles.buttonText}>Wrapped button 2</Text>
+            </TouchableOpacity>
+            <TouchableOpacity
+              ref={component => (this.rightButtonInFocusViewContainer = component)}
+              onPress={() => {}}
+              style={{
+                width,
+                height,
+              }}>
+              <Text style={styles.buttonText}>Wrapped button 3</Text>
+            </TouchableOpacity>
+          </TVFocusGuideView>
         </View>
         <View style={styles.rowContainer}>
           <TouchableOpacity
@@ -119,9 +148,23 @@ class TVFocusGuideExample extends React.Component<
             }}>
             <Text style={styles.buttonText}>Left Bottom</Text>
           </TouchableOpacity>
-          <View style={styles.focusGuide}>
+          <TVFocusGuideView style={styles.focusGuide} destinations={destinations}>
             <Text style={styles.buttonText}>Focus guide</Text>
-            <TVFocusGuideView destinations={destinations} />
+          </TVFocusGuideView>
+          <View
+            style={{
+              width,
+              height,
+            }}>
+          </View>
+          <View
+            style={{
+              width: width*3,
+              height,
+            }}>
+            <Text style={styles.buttonText}>
+              Blue focus guide container above always points to button 3 if navigating from outside
+            </Text>
           </View>
         </View>
       </View>
@@ -146,5 +189,11 @@ const styles = StyleSheet.create({
     height,
     backgroundColor: 'pink',
     opacity: 0.3,
+  },
+  containerFocusGuide: {
+    backgroundColor: 'transparent',
+    borderColor: 'blue',
+    borderWidth: 2,
+    flexDirection: 'row',
   },
 });

--- a/React/Views/RCTTVFocusGuideView.m
+++ b/React/Views/RCTTVFocusGuideView.m
@@ -17,41 +17,29 @@
 
 - (instancetype)initWithBridge:(RCTBridge *)bridge {
   if ((self = [super init])) {
-    _needsUpdateView = YES;
     _bridge = bridge;
-    [_bridge.uiManager.observerCoordinator addObserver:self];
   }
   return self;
 }
 
 - (void)invalidate {
-  [_bridge.uiManager.observerCoordinator removeObserver:self];
 }
 
-- (void)didSetProps:(NSArray<NSString *> *)changedProps {
-  _needsUpdateView = YES;
-  [super didSetProps:changedProps];
-}
-
-#pragma mark - RCTUIManagerObserver
-
-- (void)uiManagerWillPerformMounting:(__unused RCTUIManager *)uiManager {
-  if (!_needsUpdateView) {
-    return;
-  }
-  _needsUpdateView = NO;
-  
-  [_bridge.uiManager addUIBlock:^(__unused RCTUIManager *uiManager, NSDictionary<NSNumber *, UIView *> *viewRegistry) {
+- (void)setDestinationTags:(NSArray *)destinationTags {
+    NSArray *destinationTagsValue = destinationTags ? destinationTags : @[];
+    NSDictionary<NSNumber *, UIView *> *views = [_bridge.uiManager valueForKey:@"viewRegistry"];
     NSMutableArray* destinations = [NSMutableArray array];
-    for (NSNumber *  tag in self.destinationTags) {
-      RCTTVView *destination = (RCTTVView*)viewRegistry[tag];
+    for (NSNumber *  tag in destinationTagsValue) {
+      RCTTVView *destination = (RCTTVView*)views[tag];
       if (destination != nil) {
         [destinations addObject:destination];
       }
     }
     [self addFocusGuide:destinations];
-  }];
+    self->_destinationTags = destinationTagsValue;
+
 }
+
 
 - (void)addFocusGuide:(NSArray*)destinations {
   


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

- In 0.62.2, the TVFocusGuideExample in RNTester is not working correctly.  Debugging showed that the destinations prop of the focus guide was being updated too late.  This is fixed by native changes that implement a custom setter for the prop in native.
- The native implementation requires a wrapper view for the focus guide to use in setting its layout.  This PR includes changes to TVFocusGuideView.js to add a wrapper view, so app developers are no longer required to do this.  It also allows the focus guide view to wrap child components, so that the guide can direct navigation from outside to a particular focusable child component.

## Test Plan

Tested with the RNTester TVFocusGuideExample