### PR TITLE
Fix/android tv overflow and rtl

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewProps.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewProps.java
@@ -197,6 +197,7 @@ public class ViewProps {
               FLEX_SHRINK,
               FLEX_WRAP,
               JUSTIFY_CONTENT,
+              OVERFLOW,
               ALIGN_CONTENT,
               DISPLAY,
 

--- a/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollContainerView.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollContainerView.java
@@ -30,6 +30,11 @@ public class ReactHorizontalScrollContainerView extends ReactViewGroup {
 
   @Override
   protected void onLayout(boolean changed, int left, int top, int right, int bottom) {
+    // This is to fix the overflowing (scaled) item being cropped
+    HorizontalScrollView parent = (HorizontalScrollView) getParent();
+    parent.setClipChildren(false);
+    this.setClipChildren(false);
+
     if (mLayoutDirection == LAYOUT_DIRECTION_RTL) {
       // When the layout direction is RTL, we expect Yoga to give us a layout
       // that extends off the screen to the left so we re-center it with left=0
@@ -40,10 +45,10 @@ public class ReactHorizontalScrollContainerView extends ReactViewGroup {
       setRight(newRight);
 
       // Call with the present values in order to re-layout if necessary
-      HorizontalScrollView parent = (HorizontalScrollView) getParent();
+      HorizontalScrollView parentScrollView = (HorizontalScrollView) getParent();
       // Fix the ScrollX position when using RTL language
-      int offsetX = parent.getScrollX() + getWidth() - mCurrentWidth;
-      parent.scrollTo(offsetX, parent.getScrollY());
+      int offsetX = parentScrollView.getScrollX() + getWidth() - mCurrentWidth;
+      parentScrollView.scrollTo(offsetX, parentScrollView.getScrollY());
     }
     mCurrentWidth = getWidth();
   }

--- a/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollViewManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollViewManager.java
@@ -11,6 +11,7 @@ import android.graphics.Color;
 import android.util.DisplayMetrics;
 import androidx.annotation.Nullable;
 import androidx.core.view.ViewCompat;
+import com.facebook.react.modules.i18nmanager.I18nUtil;
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.module.annotations.ReactModule;
 import com.facebook.react.uimanager.DisplayMetricsHolder;
@@ -177,11 +178,38 @@ public class ReactHorizontalScrollViewManager extends ViewGroupManager<ReactHori
 
   @Override
   public void scrollTo(
-      ReactHorizontalScrollView scrollView, ReactScrollViewCommandHelper.ScrollToCommandData data) {
+          final ReactHorizontalScrollView scrollView, final ReactScrollViewCommandHelper.ScrollToCommandData data) {
+    boolean isRTL = I18nUtil.getInstance().isRTL(scrollView.getContext());
+
+    int destX = data.mDestX;
+
+    if (isRTL && scrollView.getChildAt(0) instanceof ReactHorizontalScrollContainerView) {
+      final ReactHorizontalScrollContainerView child = (ReactHorizontalScrollContainerView) scrollView.getChildAt(0);
+
+      // correct the x offset destination, as on android the scrollOffset is not adjusted to RTL
+      // i.e. the right-most part of the view will be a positive index and the left-most negative
+      destX = child.getWidth() - scrollView.getWidth() - destX;
+
+      // If the scrollContainerView is in RTL mode, fix the current scroll position in
+      // reaction to layout changes - need to listen for layout change events (e.g. because of
+      // fetching new data) and update the scroll position accordingly as soon as it's available
+      child.setListener(new ReactHorizontalScrollContainerView.Listener() {
+        @Override
+        public void onLayout() {
+          int destX = child.getWidth() - child.getLastWidth() + scrollView.getScrollX();
+
+          if (data.mAnimated) {
+            scrollView.smoothScrollTo(destX, data.mDestY);
+          } else {
+            scrollView.scrollTo(destX, data.mDestY);
+          }
+        }
+      });
+    }
     if (data.mAnimated) {
-      scrollView.smoothScrollTo(data.mDestX, data.mDestY);
+      scrollView.smoothScrollTo(destX, data.mDestY);
     } else {
-      scrollView.scrollTo(data.mDestX, data.mDestY);
+      scrollView.scrollTo(destX, data.mDestY);
     }
   }
 


### PR DESCRIPTION
## Summary

Android TV-specific fixes for RTL support and allowing views to overflow beyond the bounds of `ReactHorizontalScrollContainerView`.

## Changelog

[Android TV] [FIXED] - Allowing overflow on ReactHorizontalScrollView
[Android TV] [FIXED] - RTL support for horizontal lists

## Test Plan

### Overflow - related to https://github.com/facebook/react-native/pull/22693
* Create a horizontal `<FlatList/>` with styled items having `scale: 2` and a border around each item
* Item border **should not** be cut-off once app is launched

### RTL support
* Create a horizontal `<FlatList/>` that contains a long list of square views
* Use the Android TV developer option to force RTL for all apps
* Open test app and attempt to navigate left/right
* Horizontal list should scroll in desired direction correctly rather than pushing content off-screen