### PR TITLE
Fix/androidtv text inputs

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
@@ -7,7 +7,9 @@
 
 package com.facebook.react.views.textinput;
 
+import android.app.UiModeManager;
 import android.content.Context;
+import android.content.res.Configuration;
 import android.graphics.Rect;
 import android.graphics.Typeface;
 import android.graphics.drawable.Drawable;
@@ -107,6 +109,8 @@ public class ReactEditText extends EditText {
 
   private static final KeyListener sKeyListener = QwertyKeyListener.getInstanceForFullKeyboard();
 
+  private boolean isKeyboardOpened;
+
   public ReactEditText(Context context) {
     super(context);
     setFocusableInTouchMode(false);
@@ -156,6 +160,21 @@ public class ReactEditText extends EditText {
         });
   }
 
+  private boolean isTVDevice() {
+    UiModeManager uiModeManager = (UiModeManager) getContext().getSystemService(Context.UI_MODE_SERVICE);
+    return uiModeManager.getCurrentModeType() == Configuration.UI_MODE_TYPE_TELEVISION;
+  }
+
+  public void showKeyboard() {
+    isKeyboardOpened = true;
+    showSoftKeyboard();
+  }
+
+  public void hideKeyboard() {
+    isKeyboardOpened = false;
+    hideSoftKeyboard();
+  }
+
   // After the text changes inside an EditText, TextView checks if a layout() has been requested.
   // If it has, it will not scroll the text to the end of the new text inserted, but wait for the
   // next layout() to be called. However, we do not perform a layout() after a requestLayout(), so
@@ -180,6 +199,7 @@ public class ReactEditText extends EditText {
         // Disallow parent views to intercept touch events, until we can detect if we should be
         // capturing these touches or not.
         this.getParent().requestDisallowInterceptTouchEvent(true);
+        isKeyboardOpened = !isKeyboardOpened;
         break;
       case MotionEvent.ACTION_MOVE:
         if (mDetectScrollMovement) {
@@ -204,6 +224,9 @@ public class ReactEditText extends EditText {
     if (keyCode == KeyEvent.KEYCODE_ENTER && !isMultiline()) {
       hideSoftKeyboard();
       return true;
+    }
+    if (keyCode == KeyEvent.KEYCODE_DPAD_CENTER || keyCode == KeyEvent.KEYCODE_BACK) {
+      isKeyboardOpened = !isKeyboardOpened;
     }
     return super.onKeyUp(keyCode, event);
   }
@@ -237,6 +260,7 @@ public class ReactEditText extends EditText {
   public void clearFocus() {
     setFocusableInTouchMode(false);
     super.clearFocus();
+    isKeyboardOpened = false;
     hideSoftKeyboard();
   }
 
@@ -248,14 +272,20 @@ public class ReactEditText extends EditText {
       return true;
     }
 
-    if (!mShouldAllowFocus) {
+    if (!mShouldAllowFocus && !isTVDevice()) {
       return false;
     }
 
     setFocusableInTouchMode(true);
     boolean focused = super.requestFocus(direction, previouslyFocusedRect);
-    if (getShowSoftInputOnFocus()) {
+    if (!isTVDevice()) {
       showSoftKeyboard();
+    } else {
+      if (isKeyboardOpened) {
+        showSoftKeyboard();
+      } else {
+        hideSoftKeyboard();
+      }
     }
     return focused;
   }
@@ -317,6 +347,10 @@ public class ReactEditText extends EditText {
     super.onFocusChanged(focused, direction, previouslyFocusedRect);
     if (focused && mSelectionWatcher != null) {
       mSelectionWatcher.onSelectionChanged(getSelectionStart(), getSelectionEnd());
+    }
+
+    if (!focused) {
+      isKeyboardOpened = false;
     }
   }
 

--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
@@ -7,6 +7,7 @@
 
 package com.facebook.react.views.textinput;
 
+import android.annotation.SuppressLint;
 import android.graphics.PorterDuff;
 import android.graphics.drawable.Drawable;
 import android.os.Build;
@@ -1029,8 +1030,37 @@ public class ReactTextInputManager extends BaseViewManager<ReactEditText, Layout
                   new ReactTextInputSubmitEditingEvent(
                       editText.getId(), editText.getText().toString()));
 
-              if (blurOnSubmit) {
-                editText.clearFocus();
+              switch (actionId) {
+                case EditorInfo.IME_ACTION_PREVIOUS: {
+                  @SuppressLint("WrongConstant") View view = editText.focusSearch(View.FOCUS_BACKWARD);
+                  editText.hideKeyboard();
+                }
+                break;
+                case EditorInfo.IME_ACTION_NEXT:
+                case EditorInfo.IME_ACTION_DONE: {
+                  @SuppressLint("WrongConstant") View view = editText.focusSearch(View.FOCUS_FORWARD);
+                  if (view instanceof ReactEditText && editText.getId() != view.getId()) {
+                    view.requestFocus();
+                    ((ReactEditText) view).showKeyboard();
+                  } else {
+                    if (view != null) {
+                      view.requestFocus();
+                    }
+
+                    // manually triggering onFocusChanged when having only one input field on
+                    // the screen and no other focusable elements
+                    if (editText.getId() == view.getId()) {
+                      editText.onFocusChanged(false, View.FOCUSABLES_ALL, null);
+                    }
+                    editText.hideKeyboard();
+                  }
+                }
+                break;
+                default:
+                  if (blurOnSubmit) {
+                    editText.clearFocus();
+                  }
+                  break;
               }
 
               // Prevent default behavior except when we want it to insert a newline.


### PR DESCRIPTION
## Summary
Selecting an Android TV text input doesn't open the soft keyboard.

## Changelog

[Android TV] [FIXED] - Open soft keyboard upon selecting a text input

## Test Plan
* Create a simple view with a text input
* Attempt to enter text in the input
* Soft keyboard should appear and allow the user to enter desired text