### PR TITLE
useTVEventHandler()

### DIFF
--- a/Libraries/Components/AppleTV/useTVEventHandler.js
+++ b/Libraries/Components/AppleTV/useTVEventHandler.js
@@ -1,16 +1,16 @@
 import React from 'react';
 import TVEventHandler from './TVEventHandler';
 
-const useTVEventHandler = (ref: React.Node, handleEvent: (evt: Event) => void) => {
+const useTVEventHandler = (handleEvent: (evt: Event) => void) => {
   React.useEffect(() => {
     const handler: TVEventHandler = new TVEventHandler();
-    handler.enable(ref?.current, function(cmp, evt) {
+    handler.enable(null, function(cmp, evt) {
         handleEvent(evt);
     });
     return () => {
       handler.disable();
     };
-  }, [ref, handleEvent]);
+  }, [handleEvent]);
 };
 
 module.exports = useTVEventHandler;

--- a/Libraries/Components/AppleTV/useTVEventHandler.js
+++ b/Libraries/Components/AppleTV/useTVEventHandler.js
@@ -1,0 +1,16 @@
+import React from 'react';
+import TVEventHandler from './TVEventHandler';
+
+const useTVEventHandler = (ref: React.Node, handleEvent: (evt: Event) => void) => {
+  React.useEffect(() => {
+    const handler: TVEventHandler = new TVEventHandler();
+    handler.enable(ref?.current, function(cmp, evt) {
+        handleEvent(evt);
+    });
+    return () => {
+      handler.disable();
+    };
+  }, [ref, handleEvent]);
+};
+
+module.exports = useTVEventHandler;

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ var running_on_apple_tv = Platform.isTVOS;
   - `onBlur` will be executed when the touchable view goes out of focus
   - `onPress` will be executed when the touchable view is actually selected by pressing the "select" button on the TV remote.
 
-- _TV remote/keyboard input_: A new native class, `RCTTVRemoteHandler`, sets up gesture recognizers for TV remote events. When TV remote events occur, this class fires notifications that are picked up by `RCTTVNavigationEventEmitter` (a subclass of `RCTEventEmitter`), that fires a JS event. This event will be picked up by instances of the `TVEventHandler` JavaScript object. Application code that needs to implement custom handling of TV remote events can create an instance of `TVEventHandler` and listen for these events.  In 0.63.1-1, we have added `useTVEventHandler`, which wraps `useEffect` to make this more convenient and simpler for use with functional components.
+- _TV remote/keyboard input_: A native class, `RCTTVRemoteHandler`, sets up gesture recognizers for TV remote events. When TV remote events occur, this class fires notifications that are picked up by `RCTTVNavigationEventEmitter` (a subclass of `RCTEventEmitter`), that fires a JS event. This event will be picked up by instances of the `TVEventHandler` JavaScript object. Application code that needs to implement custom handling of TV remote events can create an instance of `TVEventHandler` and listen for these events.  In 0.63.1-1, we have added `useTVEventHandler`, which wraps `useEffect` to make this more convenient and simpler for use with functional components.
 
 ```javascript
 
@@ -96,17 +96,15 @@ import { TVEventHandler, useTVEventHandler } from 'react-native';
 const TVEventHandlerView: () => React.Node = () => {
   const [lastEventType, setLastEventType] = React.useState('');
 
-  const ref = React.useRef(null);
-
   const myTVEventHandler = evt => {
     setLastEventType(evt.eventType);
   };
 
-  useTVEventHandler(ref, myTVEventHandler);
+  useTVEventHandler(myTVEventHandler);
 
   return (
     <View>
-      <TouchableOpacity ref={ref} onPress={() => {}}>
+      <TouchableOpacity onPress={() => {}}>
         <Text>
           This example enables an instance of TVEventHandler to show the last
           event detected from the Apple TV Siri remote or from a keyboard.

--- a/README.md
+++ b/README.md
@@ -85,10 +85,40 @@ var running_on_apple_tv = Platform.isTVOS;
   - `onBlur` will be executed when the touchable view goes out of focus
   - `onPress` will be executed when the touchable view is actually selected by pressing the "select" button on the TV remote.
 
-- _TV remote/keyboard input_: A new native class, `RCTTVRemoteHandler`, sets up gesture recognizers for TV remote events. When TV remote events occur, this class fires notifications that are picked up by `RCTTVNavigationEventEmitter` (a subclass of `RCTEventEmitter`), that fires a JS event. This event will be picked up by instances of the `TVEventHandler` JavaScript object. Application code that needs to implement custom handling of TV remote events can create an instance of `TVEventHandler` and listen for these events, as in the following code:
+- _TV remote/keyboard input_: A new native class, `RCTTVRemoteHandler`, sets up gesture recognizers for TV remote events. When TV remote events occur, this class fires notifications that are picked up by `RCTTVNavigationEventEmitter` (a subclass of `RCTEventEmitter`), that fires a JS event. This event will be picked up by instances of the `TVEventHandler` JavaScript object. Application code that needs to implement custom handling of TV remote events can create an instance of `TVEventHandler` and listen for these events.  In 0.63.1-1, we have added `useTVEventHandler`, which wraps `useEffect` to make this more convenient and simpler for use with functional components.
 
 ```javascript
-var TVEventHandler = require('TVEventHandler');
+
+import { TVEventHandler, useTVEventHandler } from 'react-native';
+
+// Functional component
+
+const TVEventHandlerView: () => React.Node = () => {
+  const [lastEventType, setLastEventType] = React.useState('');
+
+  const ref = React.useRef(null);
+
+  const myTVEventHandler = evt => {
+    setLastEventType(evt.eventType);
+  };
+
+  useTVEventHandler(ref, myTVEventHandler);
+
+  return (
+    <View>
+      <TouchableOpacity ref={ref} onPress={() => {}}>
+        <Text>
+          This example enables an instance of TVEventHandler to show the last
+          event detected from the Apple TV Siri remote or from a keyboard.
+        </Text>
+      </TouchableOpacity>
+      <Text style={{color: 'blue'}}>{lastEventType}</Text>
+    </View>
+  );
+
+};
+
+// Class based component
 
 class Game2048 extends React.Component {
   _tvEventHandler: any;

--- a/RNTester/js/examples/TVEventHandler/TVEventHandlerExample.js
+++ b/RNTester/js/examples/TVEventHandler/TVEventHandlerExample.js
@@ -13,67 +13,38 @@
 const React = require('react');
 const ReactNative = require('react-native');
 
-const {Platform, View, Text, TouchableOpacity, TVEventHandler} = ReactNative;
+const {Platform, View, Text, TouchableOpacity, useTVEventHandler} = ReactNative;
 
-type Props = $ReadOnly<{||}>;
-type State = {|lastEventType: string|};
-class TVEventHandlerView extends React.Component<Props, State> {
-  constructor(props: Props) {
-    super(props);
-    this.state = {
-      lastEventType: '',
-    };
+const TVEventHandlerView: () => React.Node = () => {
+  const [lastEventType, setLastEventType] = React.useState('');
+
+  const ref = React.useRef(null);
+
+  const myTVEventHandler = evt => {
+    setLastEventType(evt.eventType);
+  };
+
+  if (Platform.isTV) {
+    useTVEventHandler(ref, myTVEventHandler); // eslint-disable-line react-hooks/rules-of-hooks
+    return (
+      <View>
+        <TouchableOpacity ref={ref} onPress={() => {}}>
+          <Text>
+            This example enables an instance of TVEventHandler to show the last
+            event detected from the Apple TV Siri remote or from a keyboard.
+          </Text>
+        </TouchableOpacity>
+        <Text style={{color: 'blue'}}>{lastEventType}</Text>
+      </View>
+    );
+  } else {
+    return (
+      <View>
+        <Text>This example is intended to be run on Apple TV.</Text>
+      </View>
+    );
   }
-
-  _tvEventHandler: any;
-
-  _enableTVEventHandler() {
-    this._tvEventHandler = new TVEventHandler();
-    this._tvEventHandler.enable(this, function(cmp, evt) {
-      cmp.setState({
-        lastEventType: evt.eventType,
-      });
-    });
-  }
-
-  _disableTVEventHandler() {
-    if (this._tvEventHandler) {
-      this._tvEventHandler.disable();
-      delete this._tvEventHandler;
-    }
-  }
-
-  componentDidMount() {
-    this._enableTVEventHandler();
-  }
-
-  componentWillUnmount() {
-    this._disableTVEventHandler();
-  }
-
-  render() {
-    if (Platform.isTV) {
-      return (
-        <View>
-          <TouchableOpacity onPress={() => {}}>
-            <Text>
-              This example enables an instance of TVEventHandler to show the
-              last event detected from the Apple TV Siri remote or from a
-              keyboard.
-            </Text>
-          </TouchableOpacity>
-          <Text style={{color: 'blue'}}>{this.state.lastEventType}</Text>
-        </View>
-      );
-    } else {
-      return (
-        <View>
-          <Text>This example is intended to be run on Apple TV.</Text>
-        </View>
-      );
-    }
-  }
-}
+};
 
 exports.framework = 'React';
 exports.title = 'TVEventHandler example';

--- a/RNTester/js/examples/TVEventHandler/TVEventHandlerExample.js
+++ b/RNTester/js/examples/TVEventHandler/TVEventHandlerExample.js
@@ -18,17 +18,15 @@ const {Platform, View, Text, TouchableOpacity, useTVEventHandler} = ReactNative;
 const TVEventHandlerView: () => React.Node = () => {
   const [lastEventType, setLastEventType] = React.useState('');
 
-  const ref = React.useRef(null);
-
   const myTVEventHandler = evt => {
     setLastEventType(evt.eventType);
   };
 
   if (Platform.isTV) {
-    useTVEventHandler(ref, myTVEventHandler); // eslint-disable-line react-hooks/rules-of-hooks
+    useTVEventHandler(myTVEventHandler); // eslint-disable-line react-hooks/rules-of-hooks
     return (
       <View>
-        <TouchableOpacity ref={ref} onPress={() => {}}>
+        <TouchableOpacity onPress={() => {}}>
           <Text>
             This example enables an instance of TVEventHandler to show the last
             event detected from the Apple TV Siri remote or from a keyboard.

--- a/index.js
+++ b/index.js
@@ -88,6 +88,7 @@ import typeof TVMenuControl from './Libraries/Components/AppleTV/TVMenuControl';
 import typeof UIManager from './Libraries/ReactNative/UIManager';
 import typeof useColorScheme from './Libraries/Utilities/useColorScheme';
 import typeof useWindowDimensions from './Libraries/Utilities/useWindowDimensions';
+import typeof useTVEventHandler from './Libraries/Components/AppleTV/useTVEventHandler';
 import typeof UTFSequence from './Libraries/UTFSequence';
 import typeof Vibration from './Libraries/Vibration/Vibration';
 import typeof YellowBox from './Libraries/YellowBox/YellowBoxDeprecated';
@@ -458,6 +459,9 @@ module.exports = {
   },
   get useWindowDimensions(): useWindowDimensions {
     return require('./Libraries/Utilities/useWindowDimensions').default;
+  },
+  get useTVEventHandler(): useTVEventHandler {
+    return require('./Libraries/Components/AppleTV/useTVEventHandler');
   },
   get UTFSequence(): UTFSequence {
     return require('./Libraries/UTFSequence');


### PR DESCRIPTION
## Summary

Add a `useEffect()` wrapper to make the `TVEventHandler` easier to use.

## Test Plan

New test code added to RNTester to show how the feature is used.