### PR TITLE
fix: Android TV text inputs functionality

### DIFF
--- a/RNTester/js/components/RNTesterExampleList.js
+++ b/RNTester/js/components/RNTesterExampleList.js
@@ -111,7 +111,7 @@ class RNTesterExampleList extends React.Component<Props, $FlowFixMeState> {
   render(): React.Node {
     const filter = ({example, filterRegex}) =>
       filterRegex.test(example.module.title) &&
-      (!Platform.isTV || example.supportsTVOS);
+      (!Platform.isTVOS || example.supportsTVOS);
 
     const sections = [
       {

--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
@@ -9,7 +9,9 @@ package com.facebook.react.views.textinput;
 
 import static com.facebook.react.uimanager.UIManagerHelper.getReactContext;
 
+import android.app.UiModeManager;
 import android.content.Context;
+import android.content.res.Configuration;
 import android.graphics.Rect;
 import android.graphics.Typeface;
 import android.graphics.drawable.Drawable;
@@ -107,6 +109,8 @@ public class ReactEditText extends AppCompatEditText {
 
   private static final KeyListener sKeyListener = QwertyKeyListener.getInstanceForFullKeyboard();
 
+  private boolean isKeyboardOpened;
+
   public ReactEditText(Context context) {
     super(context);
     setFocusableInTouchMode(false);
@@ -151,6 +155,21 @@ public class ReactEditText extends AppCompatEditText {
         });
   }
 
+  private boolean isTVDevice() {
+    UiModeManager uiModeManager = (UiModeManager) getContext().getSystemService(Context.UI_MODE_SERVICE);
+    return uiModeManager.getCurrentModeType() == Configuration.UI_MODE_TYPE_TELEVISION;
+  }
+
+  public void showKeyboard() {
+    isKeyboardOpened = true;
+    showSoftKeyboard();
+  }
+
+  public void hideKeyboard() {
+    isKeyboardOpened = false;
+    hideSoftKeyboard();
+  }
+
   // After the text changes inside an EditText, TextView checks if a layout() has been requested.
   // If it has, it will not scroll the text to the end of the new text inserted, but wait for the
   // next layout() to be called. However, we do not perform a layout() after a requestLayout(), so
@@ -175,6 +194,7 @@ public class ReactEditText extends AppCompatEditText {
         // Disallow parent views to intercept touch events, until we can detect if we should be
         // capturing these touches or not.
         this.getParent().requestDisallowInterceptTouchEvent(true);
+        isKeyboardOpened = !isKeyboardOpened;
         break;
       case MotionEvent.ACTION_MOVE:
         if (mDetectScrollMovement) {
@@ -199,6 +219,9 @@ public class ReactEditText extends AppCompatEditText {
     if (keyCode == KeyEvent.KEYCODE_ENTER && !isMultiline()) {
       hideSoftKeyboard();
       return true;
+    }
+    if (keyCode == KeyEvent.KEYCODE_DPAD_CENTER || keyCode == KeyEvent.KEYCODE_BACK) {
+      isKeyboardOpened = !isKeyboardOpened;
     }
     return super.onKeyUp(keyCode, event);
   }
@@ -232,6 +255,7 @@ public class ReactEditText extends AppCompatEditText {
   public void clearFocus() {
     setFocusableInTouchMode(false);
     super.clearFocus();
+    isKeyboardOpened = false;
     hideSoftKeyboard();
   }
 
@@ -241,16 +265,22 @@ public class ReactEditText extends AppCompatEditText {
     // is a controlled component, which means its focus is controlled by JS, with two exceptions:
     // autofocus when it's attached to the window, and responding to accessibility events. In both
     // of these cases, we call requestFocusInternal() directly.
+    // Always return true if we are already focused. This is used by android in certain places,
+    // such as text selection.
     return isFocused();
   }
 
   private boolean requestFocusInternal() {
     setFocusableInTouchMode(true);
-    // We must explicitly call this method on the super class; if we call requestFocus() without
-    // any arguments, it will call into the overridden requestFocus(int, Rect) above, which no-ops.
     boolean focused = super.requestFocus(View.FOCUS_DOWN, null);
-    if (getShowSoftInputOnFocus()) {
+    if (getShowSoftInputOnFocus() && !isTVDevice()) {
       showSoftKeyboard();
+    } else {
+      if (isKeyboardOpened) {
+        showSoftKeyboard();
+      } else {
+        hideSoftKeyboard();
+      }
     }
     return focused;
   }
@@ -321,6 +351,10 @@ public class ReactEditText extends AppCompatEditText {
     super.onFocusChanged(focused, direction, previouslyFocusedRect);
     if (focused && mSelectionWatcher != null) {
       mSelectionWatcher.onSelectionChanged(getSelectionStart(), getSelectionEnd());
+    }
+
+    if (!focused) {
+      isKeyboardOpened = false;
     }
   }
 

--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
@@ -13,6 +13,7 @@ import android.content.Context;
 import android.content.res.ColorStateList;
 import android.graphics.BlendMode;
 import android.graphics.BlendModeColorFilter;
+import android.annotation.SuppressLint;
 import android.graphics.PorterDuff;
 import android.graphics.drawable.Drawable;
 import android.os.Build;
@@ -1065,8 +1066,37 @@ public class ReactTextInputManager extends BaseViewManager<ReactEditText, Layout
                   new ReactTextInputSubmitEditingEvent(
                       editText.getId(), editText.getText().toString()));
 
-              if (blurOnSubmit) {
-                editText.clearFocus();
+              switch (actionId) {
+                case EditorInfo.IME_ACTION_PREVIOUS: {
+                  @SuppressLint("WrongConstant") View view = editText.focusSearch(View.FOCUS_BACKWARD);
+                  editText.hideKeyboard();
+                }
+                break;
+                case EditorInfo.IME_ACTION_NEXT:
+                case EditorInfo.IME_ACTION_DONE: {
+                  @SuppressLint("WrongConstant") View view = editText.focusSearch(View.FOCUS_FORWARD);
+                  if (view instanceof ReactEditText && editText.getId() != view.getId()) {
+                    view.requestFocus();
+                    ((ReactEditText) view).showKeyboard();
+                  } else {
+                    if (view != null) {
+                      view.requestFocus();
+                    }
+
+                    // manually triggering onFocusChanged when having only one input field on
+                    // the screen and no other focusable elements
+                    if (editText.getId() == view.getId()) {
+                      editText.onFocusChanged(false, View.FOCUSABLES_ALL, null);
+                    }
+                    editText.hideKeyboard();
+                  }
+                }
+                break;
+                default:
+                  if (blurOnSubmit) {
+                    editText.clearFocus();
+                  }
+                  break;
               }
 
               // Prevent default behavior except when we want it to insert a newline.


### PR DESCRIPTION
Signed-off-by: Ventsislav Dimitrov <4097884+vdmtrv@users.noreply.github.com>

## Summary
Selecting an Android TV text input doesn't open the soft keyboard.
(This is merged from the original commit on the 0.62 release branch)

## Changelog

[Android TV] [FIXED] - Open soft keyboard upon selecting a text input

## Test Plan
* Create a simple view with a text input
* Attempt to enter text in the input
* Soft keyboard should appear and allow the user to enter desired text