### PR TITLE
feat: nextFocus for iOS

### DIFF
--- a/Libraries/Components/AppleTV/TVFocusGuideView.js
+++ b/Libraries/Components/AppleTV/TVFocusGuideView.js
@@ -39,21 +39,20 @@ class TVFocusGuideView extends React.Component<FocusGuideProps> {
   }
 
   render(): React.Node {
-    if (Platform.isTVOS) {
-      return (
-        // Container view must have nonzero size
-        <ReactNative.View style={[{minHeight: 1, minWidth: 1}, this.props.style]}>
+    return (
+      // Container view must have nonzero size
+      <ReactNative.View style={[{minHeight: 1, minWidth: 1}, this.props.style]}>
+        {Platform.isTVOS ? (
           <RNFocusGuide
             style={this.props.style}
             ref={ref => (this._focusGuideRef = ref)}
-            destinationTags={this._destinationTags}
-          >
+            destinationTags={this._destinationTags}>
             {this.props.children}
           </RNFocusGuide>
-        </ReactNative.View>
-      );
-    }
-    return <React.Fragment />;
+        ) : (
+          this.props.children
+        )}
+      </ReactNative.View>)
   }
 }
 

--- a/Libraries/Components/View/ViewPropTypes.js
+++ b/Libraries/Components/View/ViewPropTypes.js
@@ -294,39 +294,11 @@ type AndroidViewProps = $ReadOnly<{|
   importantForAccessibility?: ?('auto' | 'yes' | 'no' | 'no-hide-descendants'),
 
   /**
-   * TV next focus down (see documentation for the View component).
-   *
-   * @platform android
-   */
-  nextFocusDown?: ?number,
-
-  /**
    * TV next focus forward (see documentation for the View component).
    *
    * @platform android
    */
   nextFocusForward?: ?number,
-
-  /**
-   * TV next focus left (see documentation for the View component).
-   *
-   * @platform android
-   */
-  nextFocusLeft?: ?number,
-
-  /**
-   * TV next focus right (see documentation for the View component).
-   *
-   * @platform android
-   */
-  nextFocusRight?: ?number,
-
-  /**
-   * TV next focus up (see documentation for the View component).
-   *
-   * @platform android
-   */
-  nextFocusUp?: ?number,
 
   /**
    * Whether this `View` should be focusable with a non-touch input device, eg. receive focus with a hardware keyboard.
@@ -382,6 +354,32 @@ type IOSViewProps = $ReadOnly<{|
   shouldRasterizeIOS?: ?boolean,
 |}>;
 
+type NextFocusProps = $ReadOnly<{|
+  /**
+   * TV next focus down (see documentation for the View component).
+   *
+   */
+  nextFocusDown?: ?number,
+
+  /**
+   * TV next focus left (see documentation for the View component).
+   *
+   */
+  nextFocusLeft?: ?number,
+
+  /**
+   * TV next focus right (see documentation for the View component).
+   *
+   */
+  nextFocusRight?: ?number,
+
+  /**
+   * TV next focus up (see documentation for the View component).
+   *
+   */
+  nextFocusUp?: ?number,
+|}>;
+
 export type ViewProps = $ReadOnly<{|
   ...BubblingEventProps,
   ...DirectEventProps,
@@ -391,6 +389,7 @@ export type ViewProps = $ReadOnly<{|
   ...AndroidViewProps,
   ...IOSViewProps,
   ...TVViewProps,
+  ...NextFocusProps,
 
   children?: Node,
   style?: ?ViewStyleProp,

--- a/README.md
+++ b/README.md
@@ -179,6 +179,8 @@ class Game2048 extends React.Component {
 
 - _TVFocusGuideView_: This component provides support for Apple's `UIFocusGuide` API, to help ensure that focusable controls can be navigated to, even if they are not directly in line with other controls.  An example is provided in `RNTester` that shows two different ways of using this component.
 
+- _Next Focus Direction_: the props `nextFocus*` on `View` should work as expected on iOS too (previously android only). One caveat is that if there is no focusable in the `nextFocusable*` direction next to the starting view, iOS doesn't check if we want to override the destination. 
+
 - _TVTextScrollView_: On Apple TV, a ScrollView will not scroll unless there are focusable items inside it or above/below it.  This component wraps ScrollView and uses tvOS-specific native code to allow scrolling using swipe gestures from the remote control.
 
 - _Known issues_:

--- a/RNTester/Podfile.lock
+++ b/RNTester/Podfile.lock
@@ -426,7 +426,7 @@ SPEC CHECKSUMS:
   boost-for-react-native: 39c7adb57c4e60d6c5479dd8623128eb5b3f0f2c
   CocoaAsyncSocket: 694058e7c0ed05a9e217d1b3c7ded962f4180845
   CocoaLibEvent: 80507925cc2857ace161e25ac1000745c145ac19
-  DoubleConversion: cde416483dac037923206447da6e1454df403714
+  DoubleConversion: 5805e889d232975c086db112ece9ed034df7a0b2
   FBLazyVector: 5942dd8c3a12edc83c6a6d0717a824f541fda0d9
   FBReactNativeSpec: 77817fd2905a7de8dfaa2e3fba0258d29847b77d
   Flipper: b96fca3f1d3cfcb78df7d8eaed51ea9a71b69e92
@@ -437,7 +437,7 @@ SPEC CHECKSUMS:
   Flipper-RSocket: d4c7baf814323f8f0911559944b87bbbd3c63da4
   FlipperKit: 31028f4bd9b85b8f2a98aa4d7f169b394d009439
   Folly: b73c3869541e86821df3c387eb0af5f65addfab4
-  glog: 40a13f7840415b9a77023fbcae0f1e6f43192af3
+  glog: 1f3da668190260b06b429bb211bfbee5cd790c28
   OpenSSL-Universal: 7cbe4bc3c032ace1c0ce897d6b5d58a3b9f6b8e2
   RCTRequired: d61a2971ac821f58d742aab72ed7d48675f7d3d0
   RCTTypeSafety: fdee8013e73626078d006d2f7873db1bcece8e06

--- a/RNTester/js/examples/DirectionalNextFocus/DirectionalNextFocusExample.js
+++ b/RNTester/js/examples/DirectionalNextFocus/DirectionalNextFocusExample.js
@@ -1,0 +1,191 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @flow
+ */
+
+'use strict';
+
+const React = require('react');
+const ReactNative = require('react-native');
+
+const {View, StyleSheet, TouchableOpacity, Text, findNodeHandle} = ReactNative;
+
+exports.framework = 'React';
+exports.title = 'DirectionalNextFocus example';
+exports.description = 'tvOS nextFocus';
+exports.examples = [
+  {
+    title: 'DirectionalNextFocus',
+    render(): React.Node {
+      return <DirectionalNextFocusExample />;
+    },
+  },
+];
+
+const padding = 100;
+const width = 200;
+const height = 120;
+
+class DirectionalNextFocusExample extends React.Component<
+  $FlowFixMeProps,
+  {
+    destinations: {
+      up: ?Object,
+      down: ?Object,
+      left: ?Object,
+      right: ?Object,
+    },
+  },
+> {
+  constructor(props: Object) {
+    super(props);
+    this.state = {
+      destinations: {
+        up: undefined,
+        down: undefined,
+        left: undefined,
+        right: undefined,
+      },
+    };
+  }
+
+  render() {
+    const {destinations} = this.state;
+    return (
+      <View style={styles.container}>
+        <View style={styles.rowContainer}>
+          <TouchableOpacity
+            nextFocusUp={destinations.up}
+            nextFocusDown={destinations.down}
+            nextFocusLeft={destinations.left}
+            nextFocusRight={destinations.right}
+            style={{
+              width,
+              height,
+            }}>
+            <Text style={styles.buttonText}>Starting point</Text>
+          </TouchableOpacity>
+          <TouchableOpacity
+            ref={component =>
+              this.setState(prevState => ({
+                destinations: {
+                  ...prevState.destinations,
+                  up: findNodeHandle(component),
+                },
+              }))
+            }
+            style={{
+              width,
+              height,
+            }}>
+            <Text style={styles.buttonText}>nextUp destination</Text>
+          </TouchableOpacity>
+          <View style={styles.containerFocusGuide}>
+            <TouchableOpacity
+              style={{
+                width,
+                height,
+              }}>
+              <Text style={styles.buttonText}>Wrapped button 1</Text>
+            </TouchableOpacity>
+            <TouchableOpacity
+              ref={component =>
+                this.setState(prevState => ({
+                  destinations: {
+                    ...prevState.destinations,
+                    down: findNodeHandle(component),
+                  },
+                }))
+              }
+              style={{
+                width,
+                height,
+              }}>
+              <Text style={styles.buttonText}>nextDown destination</Text>
+            </TouchableOpacity>
+            <TouchableOpacity
+              style={{
+                width,
+                height,
+              }}>
+              <Text style={styles.buttonText}>Wrapped button 3</Text>
+            </TouchableOpacity>
+          </View>
+        </View>
+        <View style={styles.rowContainer}>
+          <TouchableOpacity
+            ref={component =>
+              this.setState(prevState => ({
+                destinations: {
+                  ...prevState.destinations,
+                  right: findNodeHandle(component),
+                },
+              }))
+            }
+            style={{
+              width,
+              height,
+            }}>
+            <Text style={styles.buttonText}>nextRight destination</Text>
+          </TouchableOpacity>
+          <View
+            style={{
+              width,
+              height,
+            }}
+          />
+          <TouchableOpacity
+            ref={component =>
+              this.setState(prevState => ({
+                destinations: {
+                  ...prevState.destinations,
+                  left: findNodeHandle(component),
+                },
+              }))
+            }
+            style={{
+              width: width * 3,
+              height,
+            }}>
+            <Text style={styles.buttonText}>nextLeft destination</Text>
+            <Text style={styles.buttonText}>
+              does not work because there is no "real" focusable in the
+              direction
+            </Text>
+          </TouchableOpacity>
+        </View>
+      </View>
+    );
+  }
+}
+
+const styles = StyleSheet.create({
+  container: {
+    marginTop: -20,
+    backgroundColor: 'transparent',
+  },
+  rowContainer: {
+    flexDirection: 'row',
+    padding,
+  },
+  buttonText: {
+    fontSize: 30,
+  },
+  focusGuide: {
+    width,
+    height,
+    backgroundColor: 'pink',
+    opacity: 0.3,
+  },
+  containerFocusGuide: {
+    backgroundColor: 'transparent',
+    borderColor: 'blue',
+    borderWidth: 2,
+    flexDirection: 'row',
+  },
+});

--- a/RNTester/js/utils/RNTesterList.ios.js
+++ b/RNTester/js/utils/RNTesterList.ios.js
@@ -340,6 +340,11 @@ const APIExamples: Array<RNTesterExample> = [
     supportsTVOS: true,
   },
   {
+    key: 'DirectionalNextFocusExample',
+    module: require('../examples/DirectionalNextFocus/DirectionalNextFocusExample'),
+    supportsTVOS: true,
+  },
+  {
     key: 'TVFocusGuideExample',
     module: require('../examples/TVFocusGuide/TVFocusGuideExample'),
     supportsTVOS: true,

--- a/React/Views/RCTTVView.h
+++ b/React/Views/RCTTVView.h
@@ -9,6 +9,7 @@
 #import <UIKit/UIKit.h>
 
 #import <React/RCTView.h>
+#import <React/RCTBridge.h>
 
 //  A RCTView with additional properties and methods for user interaction using the Apple TV focus engine.
 @interface RCTTVView : RCTView
@@ -29,6 +30,17 @@
 @property (nonatomic, assign) BOOL hasTVPreferredFocus;
 
 /**
+ * Focus direction tags
+ */
+@property (nonatomic, strong) RCTTVView * nextFocusUp;
+@property (nonatomic, strong) RCTTVView * nextFocusDown;
+@property (nonatomic, strong) RCTTVView * nextFocusLeft;
+@property (nonatomic, strong) RCTTVView * nextFocusRight;
+@property (nonatomic, strong) RCTTVView * nextFocusActiveTarget;
+
+- (instancetype)initWithBridge:(RCTBridge *)bridge;
+
+/**
  * Send Focus Notifications to listeners
  */
 - (void)sendFocusNotification:(UIFocusUpdateContext *)context;
@@ -45,7 +57,7 @@
 
 /**
  * Adds Parallax Motion Effects if tvParallaxProperty is enabled
- */ 
+ */
 - (void)addParallaxMotionEffects;
 
 /**

--- a/React/Views/RCTTVView.m
+++ b/React/Views/RCTTVView.m
@@ -296,33 +296,26 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder : unused)
   object:@{@"eventType":@"blur",@"tag":self.reactTag}];
 }
 
-- (void)setNextFocusUp:(NSNumber *)nextFocusUp {
-  if (nextFocusUp == nil) return;
+- (RCTTVView *)getViewById:(NSNumber *)viewId {
+  if (viewId == nil) return nil;
   NSDictionary<NSNumber *, UIView *> *views = [_bridge.uiManager valueForKey:@"viewRegistry"];
-  RCTTVView *destination = (RCTTVView*)views[nextFocusUp];
-    self->_nextFocusUp = destination;
+  return (RCTTVView*)views[viewId];
+}
+
+- (void)setNextFocusUp:(NSNumber *)nextFocusUp {
+  self->_nextFocusUp = [self getViewById: nextFocusUp];
 }
 
 - (void)setNextFocusDown:(NSNumber *)nextFocusDown {
-  if (nextFocusDown == nil) return;
-  NSDictionary<NSNumber *, UIView *> *views = [_bridge.uiManager valueForKey:@"viewRegistry"];
-  RCTTVView *destination = (RCTTVView*)views[nextFocusDown];
-    self->_nextFocusDown = destination;
+    self->_nextFocusDown = [self getViewById: nextFocusDown];
 }
 
 - (void)setNextFocusLeft:(NSNumber *)nextFocusLeft {
-  if (nextFocusLeft == nil) return;
-  NSDictionary<NSNumber *, UIView *> *views = [_bridge.uiManager valueForKey:@"viewRegistry"];
-  RCTTVView *destination = (RCTTVView*)views[nextFocusLeft];
-    self->_nextFocusLeft = destination;
+    self->_nextFocusLeft = [self getViewById: nextFocusLeft];
 }
 
 - (void)setNextFocusRight:(NSNumber *)nextFocusRight {
-    if (nextFocusRight == nil) return;
-  NSDictionary<NSNumber *, UIView *> *views = [_bridge.uiManager valueForKey:@"viewRegistry"];
-  RCTTVView *destination = (RCTTVView*)views[nextFocusRight];
-
-    self->_nextFocusRight = destination;
+    self->_nextFocusRight = [self getViewById: nextFocusRight];
 }
 
 - (void)setPreferredFocus:(BOOL)hasTVPreferredFocus

--- a/React/Views/RCTTVView.m
+++ b/React/Views/RCTTVView.m
@@ -43,7 +43,7 @@
     self.tvParallaxProperties = defaultTVParallaxProperties;
     motionEffectsAdded = NO;
   }
-
+  
   return self;
 }
 
@@ -56,7 +56,7 @@ static dispatch_once_t onceToken;
     _tvParallaxProperties = [defaultTVParallaxProperties copy];
     return;
   }
-
+  
   NSMutableDictionary *newParallaxProperties = [NSMutableDictionary dictionaryWithDictionary:_tvParallaxProperties];
   for (NSString *k in [defaultTVParallaxProperties allKeys]) {
     if (tvParallaxProperties[k]) {
@@ -89,38 +89,38 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder : unused)
   if ([self.tvParallaxProperties[@"enabled"] boolValue] == YES) {
     float magnification = [self.tvParallaxProperties[@"magnification"] floatValue];
     float pressMagnification = [self.tvParallaxProperties[@"pressMagnification"] floatValue];
-
+    
     // Duration of press animation
     float pressDuration = [self.tvParallaxProperties[@"pressDuration"] floatValue];
-
+    
     // Delay of press animation
     float pressDelay = [self.tvParallaxProperties[@"pressDelay"] floatValue];
-
+    
     [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:pressDelay]];
-
+    
     [UIView animateWithDuration:(pressDuration/2)
-      animations:^{
-        self.transform = CGAffineTransformMakeScale(pressMagnification, pressMagnification);
+                     animations:^{
+      self.transform = CGAffineTransformMakeScale(pressMagnification, pressMagnification);
+    }
+                     completion:^(__unused BOOL finished1){
+      [UIView animateWithDuration:(pressDuration/2)
+                       animations:^{
+        self.transform = CGAffineTransformMakeScale(magnification, magnification);
       }
-      completion:^(__unused BOOL finished1){
-        [UIView animateWithDuration:(pressDuration/2)
-          animations:^{
-            self.transform = CGAffineTransformMakeScale(magnification, magnification);
-          }
-          completion:^(__unused BOOL finished2) {
-            [self sendSelectNotification:r];
-          }];
-       }];
-
-	} else {
-		[self sendSelectNotification:r];
-	}
+                       completion:^(__unused BOOL finished2) {
+        [self sendSelectNotification:r];
+      }];
+    }];
+    
+  } else {
+    [self sendSelectNotification:r];
+  }
 }
 
 - (void)sendSelectNotification:(__unused UIGestureRecognizer *)recognizer
 {
   [[NSNotificationCenter defaultCenter] postNotificationName:@"RCTTVNavigationEventNotification"
-  object:@{@"eventType":@"select",@"tag":self.reactTag}];
+                                                      object:@{@"eventType":@"select",@"tag":self.reactTag}];
 }
 
 - (BOOL)isUserInteractionEnabled
@@ -138,79 +138,79 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder : unused)
   if(![self.tvParallaxProperties[@"enabled"] boolValue]) {
     return;
   }
-
+  
   if(motionEffectsAdded == YES) {
     return;
   }
-
+  
   // Size of shift movements
   CGFloat const shiftDistanceX = [self.tvParallaxProperties[@"shiftDistanceX"] floatValue];
   CGFloat const shiftDistanceY = [self.tvParallaxProperties[@"shiftDistanceY"] floatValue];
-
+  
   // Make horizontal movements shift the centre left and right
   UIInterpolatingMotionEffect *xShift =
-      [[UIInterpolatingMotionEffect alloc] initWithKeyPath:@"center.x"
-                                                      type:UIInterpolatingMotionEffectTypeTiltAlongHorizontalAxis];
+  [[UIInterpolatingMotionEffect alloc] initWithKeyPath:@"center.x"
+                                                  type:UIInterpolatingMotionEffectTypeTiltAlongHorizontalAxis];
   xShift.minimumRelativeValue = @(shiftDistanceX * -1.0f);
   xShift.maximumRelativeValue = @(shiftDistanceX);
-
+  
   // Make vertical movements shift the centre up and down
   UIInterpolatingMotionEffect *yShift =
-      [[UIInterpolatingMotionEffect alloc] initWithKeyPath:@"center.y"
-                                                      type:UIInterpolatingMotionEffectTypeTiltAlongVerticalAxis];
+  [[UIInterpolatingMotionEffect alloc] initWithKeyPath:@"center.y"
+                                                  type:UIInterpolatingMotionEffectTypeTiltAlongVerticalAxis];
   yShift.minimumRelativeValue = @(shiftDistanceY * -1.0f);
   yShift.maximumRelativeValue = @(shiftDistanceY);
-
+  
   // Size of tilt movements
   CGFloat const tiltAngle = [self.tvParallaxProperties[@"tiltAngle"] floatValue];
-
+  
   // Now make horizontal movements effect a rotation about the Y axis for side-to-side rotation.
   UIInterpolatingMotionEffect *xTilt =
-      [[UIInterpolatingMotionEffect alloc] initWithKeyPath:@"layer.transform"
-                                                      type:UIInterpolatingMotionEffectTypeTiltAlongHorizontalAxis];
-
+  [[UIInterpolatingMotionEffect alloc] initWithKeyPath:@"layer.transform"
+                                                  type:UIInterpolatingMotionEffectTypeTiltAlongHorizontalAxis];
+  
   // CATransform3D value for minimumRelativeValue
   CATransform3D transMinimumTiltAboutY = CATransform3DIdentity;
   transMinimumTiltAboutY.m34 = 1.0 / 500;
   transMinimumTiltAboutY = CATransform3DRotate(transMinimumTiltAboutY, tiltAngle * -1.0, 0, 1, 0);
-
+  
   // CATransform3D value for minimumRelativeValue
   CATransform3D transMaximumTiltAboutY = CATransform3DIdentity;
   transMaximumTiltAboutY.m34 = 1.0 / 500;
   transMaximumTiltAboutY = CATransform3DRotate(transMaximumTiltAboutY, tiltAngle, 0, 1, 0);
-
+  
   // Set the transform property boundaries for the interpolation
   xTilt.minimumRelativeValue = [NSValue valueWithCATransform3D:transMinimumTiltAboutY];
   xTilt.maximumRelativeValue = [NSValue valueWithCATransform3D:transMaximumTiltAboutY];
-
+  
   // Now make vertical movements effect a rotation about the X axis for up and down rotation.
   UIInterpolatingMotionEffect *yTilt =
-      [[UIInterpolatingMotionEffect alloc] initWithKeyPath:@"layer.transform"
-                                                      type:UIInterpolatingMotionEffectTypeTiltAlongVerticalAxis];
-
+  [[UIInterpolatingMotionEffect alloc] initWithKeyPath:@"layer.transform"
+                                                  type:UIInterpolatingMotionEffectTypeTiltAlongVerticalAxis];
+  
   // CATransform3D value for minimumRelativeValue
   CATransform3D transMinimumTiltAboutX = CATransform3DIdentity;
   transMinimumTiltAboutX.m34 = 1.0 / 500;
   transMinimumTiltAboutX = CATransform3DRotate(transMinimumTiltAboutX, tiltAngle * -1.0, 1, 0, 0);
-
+  
   // CATransform3D value for minimumRelativeValue
   CATransform3D transMaximumTiltAboutX = CATransform3DIdentity;
   transMaximumTiltAboutX.m34 = 1.0 / 500;
   transMaximumTiltAboutX = CATransform3DRotate(transMaximumTiltAboutX, tiltAngle, 1, 0, 0);
-
+  
   // Set the transform property boundaries for the interpolation
   yTilt.minimumRelativeValue = [NSValue valueWithCATransform3D:transMinimumTiltAboutX];
   yTilt.maximumRelativeValue = [NSValue valueWithCATransform3D:transMaximumTiltAboutX];
-
+  
   // Add all of the motion effects to this group
   self.motionEffects = @[ xShift, yShift, xTilt, yTilt ];
-
+  
   float magnification = [self.tvParallaxProperties[@"magnification"] floatValue];
-
+  
   [UIView animateWithDuration:0.2 animations:^{
     self.transform = CGAffineTransformScale(self.transform, magnification, magnification);
   }];
-
+  
   motionEffectsAdded = YES;
 }
 
@@ -219,7 +219,7 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder : unused)
   if(motionEffectsAdded == NO) {
     return;
   }
-
+  
   [UIView animateWithDuration:0.2 animations:^{
     float magnification = [self.tvParallaxProperties[@"magnification"] floatValue];
     BOOL enabled = [self.tvParallaxProperties[@"enabled"] boolValue];
@@ -227,11 +227,11 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder : unused)
       self.transform = CGAffineTransformScale(self.transform, 1.0/magnification, 1.0/magnification);
     }
   }];
-
+  
   for (UIMotionEffect *effect in [self.motionEffects copy]){
     [self removeMotionEffect:effect];
   }
-
+  
   motionEffectsAdded = NO;
 }
 
@@ -257,43 +257,52 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder : unused)
 }
 
 - (BOOL) shouldUpdateFocusInContext:(UIFocusUpdateContext *)context {
-  if (_nextFocusUp != nil && context.focusHeading == UIFocusHeadingUp) {
-    self->_nextFocusActiveTarget = _nextFocusUp;
-    [self setNeedsFocusUpdate];
-    return false;
+  if (self.isFocused) {
+    if (_nextFocusUp != nil && context.focusHeading == UIFocusHeadingUp) {
+      self->_nextFocusActiveTarget = _nextFocusUp;
+      [self setNeedsFocusUpdate];
+      return false;
+    }
+    if (_nextFocusDown != nil && context.focusHeading == UIFocusHeadingDown) {
+      self->_nextFocusActiveTarget = _nextFocusDown;
+      [self setNeedsFocusUpdate];
+      return false;
+    }
+    if (_nextFocusLeft != nil && context.focusHeading == UIFocusHeadingLeft) {
+      self->_nextFocusActiveTarget = _nextFocusLeft;
+      [self setNeedsFocusUpdate];
+      return false;
+    }
+    if (_nextFocusRight != nil && context.focusHeading == UIFocusHeadingRight) {
+      self->_nextFocusActiveTarget = _nextFocusRight;
+      [self setNeedsFocusUpdate];
+      return false;
+    }
+    self->_nextFocusActiveTarget = nil;
+    return true;
   }
-  if (_nextFocusDown != nil && context.focusHeading == UIFocusHeadingDown) {
-    self->_nextFocusActiveTarget = _nextFocusDown;
-    [self setNeedsFocusUpdate];
-    return false;
-  }
-  if (_nextFocusLeft != nil && context.focusHeading == UIFocusHeadingLeft) {
-    self->_nextFocusActiveTarget = _nextFocusLeft;
-    [self setNeedsFocusUpdate];
-    return false;
-  }
-  if (_nextFocusRight != nil && context.focusHeading == UIFocusHeadingRight) {
-    self->_nextFocusActiveTarget = _nextFocusRight;
-    [self setNeedsFocusUpdate];
-    return false;
-  }
+  self->_nextFocusActiveTarget = nil;
   return true;
 }
 
 - (NSArray<id<UIFocusEnvironment>> *)preferredFocusEnvironments {
-  return _nextFocusActiveTarget != nil ? @[_nextFocusActiveTarget] : [super preferredFocusEnvironments];
+  if (_nextFocusActiveTarget == nil) return [super preferredFocusEnvironments];
+  RCTTVView * nextFocusActiveTarget = _nextFocusActiveTarget;
+  _nextFocusActiveTarget = nil;
+  NSArray<id<UIFocusEnvironment>> * focusEnvironment = @[nextFocusActiveTarget];
+  return focusEnvironment;
 }
 
 - (void)sendFocusNotification:(__unused UIFocusUpdateContext *)context
 {
   [[NSNotificationCenter defaultCenter] postNotificationName:@"RCTTVNavigationEventNotification"
-  object:@{@"eventType":@"focus",@"tag":self.reactTag}];
+                                                      object:@{@"eventType":@"focus",@"tag":self.reactTag}];
 }
 
 - (void)sendBlurNotification:(__unused UIFocusUpdateContext *)context
 {
   [[NSNotificationCenter defaultCenter] postNotificationName:@"RCTTVNavigationEventNotification"
-  object:@{@"eventType":@"blur",@"tag":self.reactTag}];
+                                                      object:@{@"eventType":@"blur",@"tag":self.reactTag}];
 }
 
 - (RCTTVView *)getViewById:(NSNumber *)viewId {
@@ -307,15 +316,15 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder : unused)
 }
 
 - (void)setNextFocusDown:(NSNumber *)nextFocusDown {
-    self->_nextFocusDown = [self getViewById: nextFocusDown];
+  self->_nextFocusDown = [self getViewById: nextFocusDown];
 }
 
 - (void)setNextFocusLeft:(NSNumber *)nextFocusLeft {
-    self->_nextFocusLeft = [self getViewById: nextFocusLeft];
+  self->_nextFocusLeft = [self getViewById: nextFocusLeft];
 }
 
 - (void)setNextFocusRight:(NSNumber *)nextFocusRight {
-    self->_nextFocusRight = [self getViewById: nextFocusRight];
+  self->_nextFocusRight = [self getViewById: nextFocusRight];
 }
 
 - (void)setPreferredFocus:(BOOL)hasTVPreferredFocus
@@ -328,9 +337,9 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder : unused)
         rootview = [rootview superview];
       }
       if (rootview == nil) return;
-
+      
       rootview = [rootview superview];
-
+      
       [(RCTRootView *)rootview setReactPreferredFocusedView:self];
       [rootview setNeedsFocusUpdate];
       [rootview updateFocusIfNeeded];
@@ -349,9 +358,9 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder : unused)
       }
       if (rootview == nil)
         return;
-
+      
       rootview = [rootview superview];
-
+      
       [(RCTRootView *)rootview setReactPreferredFocusedView:self];
       [rootview setNeedsFocusUpdate];
       [rootview updateFocusIfNeeded];

--- a/React/Views/RCTViewManager.m
+++ b/React/Views/RCTViewManager.m
@@ -84,7 +84,7 @@ RCT_EXPORT_MODULE()
 - (UIView *)view
 {
 #if TARGET_OS_TV
-  return [RCTTVView new];
+  return [[RCTTVView alloc] initWithBridge:self.bridge];
 #else
   return [RCTView new];
 #endif
@@ -123,6 +123,10 @@ RCT_EXPORT_MODULE()
 RCT_EXPORT_VIEW_PROPERTY(isTVSelectable, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(hasTVPreferredFocus, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(tvParallaxProperties, NSDictionary)
+RCT_EXPORT_VIEW_PROPERTY(nextFocusUp, NSNumber)
+RCT_EXPORT_VIEW_PROPERTY(nextFocusDown, NSNumber)
+RCT_EXPORT_VIEW_PROPERTY(nextFocusLeft, NSNumber)
+RCT_EXPORT_VIEW_PROPERTY(nextFocusRight, NSNumber)
 #endif
 
 // Accessibility related properties

--- a/tvos-types.d.ts
+++ b/tvos-types.d.ts
@@ -2,6 +2,35 @@ import React from 'react';
 import { ViewProps, ScrollViewProps } from 'react-native';
 
 declare module 'react-native' {
+  interface ViewProps {
+  /**
+   * TV next focus down (see documentation for the View component).
+   */
+  nextFocusDown?: number,
+
+  /**
+   * TV next focus forward (see documentation for the View component).
+   * 
+   * @platform android
+   */
+  nextFocusForward?: number,
+
+  /**
+   * TV next focus left (see documentation for the View component).
+   */
+  nextFocusLeft?: number,
+
+  /**
+   * TV next focus right (see documentation for the View component).
+   */
+  nextFocusRight?: number,
+
+  /**
+   * TV next focus up (see documentation for the View component).
+   */
+  nextFocusUp?: number,
+  }
+
   export const useTVEventHandler: (handleEvent: (event: HWKeyEvent) => void) => void;
 
   export const TVMenuControl: {


### PR DESCRIPTION
## Summary

I've found android's focus guidance api more powerful, and since it's already there, and possible to implement for iOS (mostly), why not give more options to devs?

## Changelog

[tvOS] [FEAT] - Add directional next focus targetability

## Test Plan

- create 3 views below each other
- target the next one on `nextFocusRight`
- observe the one below getting focus
