### PR TITLE
Disable multiline TextInput for tvOS (#109)

### DIFF
--- a/Libraries/Components/TextInput/TextInput.js
+++ b/Libraries/Components/TextInput/TextInput.js
@@ -24,6 +24,8 @@ const invariant = require('invariant');
 const nullthrows = require('nullthrows');
 const setAndForwardRef = require('../../Utilities/setAndForwardRef');
 
+const warnOnce = require('../../Utilities/warnOnce');
+
 import type {TextStyleProp, ViewStyleProp} from '../../StyleSheet/StyleSheet';
 import type {ColorValue} from '../../StyleSheet/StyleSheetTypes';
 import type {ViewProps} from '../View/ViewPropTypes';
@@ -1059,16 +1061,25 @@ function InternalTextInput(props: Props): React.Node {
   |} = {...null};
 
   if (Platform.OS === 'ios') {
-    const RCTTextInputView = props.multiline
-      ? RCTMultilineTextInputView
-      : RCTSinglelineTextInputView;
+    const RCTTextInputView =
+      props.multiline && !Platform.isTVOS
+        ? RCTMultilineTextInputView
+        : RCTSinglelineTextInputView;
 
-    const style = props.multiline
-      ? [styles.multilineInput, props.style]
-      : props.style;
+    const style =
+      props.multiline && !Platform.isTVOS
+        ? [styles.multilineInput, props.style]
+        : props.style;
 
     additionalTouchableProps.rejectResponderTermination =
       props.rejectResponderTermination;
+
+    if (props.multiline && Platform.isTVOS) {
+      warnOnce(
+        'text-input-multiline-tvos',
+        'Multiline TextInput not supported on Apple TV.  See https://github.com/react-native-community/react-native-tvos/issues/109',
+      );
+    }
 
     textInput = (
       <RCTTextInputView


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

- Disables multiline TextInput for tvOS (the native OS does not support it), so that the text input will actually function on tvOS (#109 )
- Adds a `warnOnce()` call if user tries to use multiline on tvOS

## Test Plan

Tested on a tvOS device.
