### PR TITLE
fix: hacky type extension import

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ You cannot use this package and the core react-native package simultaneously in 
 Due to the nature of the typing resolution, the current solution to include types is to:
 
 - install `@types/react-native` as a dev dependency
-- put `import 'react-native/tvos-types'` in any of your `.ts` files (root suggested)
+- put `import 'react-native/tvos-types.d'` in any of your `.ts` files (root suggested)
 
 ## General support for Apple TV
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,13 @@ To build your project for Apple TV, you should change your `package.json` import
 
 You cannot use this package and the core react-native package simultaneously in a project.
 
+### Typescript
+
+Due to the nature of the typing resolution, the current solution to include types is to:
+
+- install `@types/react-native` as a dev dependency
+- put `import 'react-native/tvos-types'` in any of your `.ts` files (root suggested)
+
 ## General support for Apple TV
 
 TV devices support has been implemented with the intention of making existing React Native applications "just work" on Apple TV, with few or no changes needed in the JavaScript code for the applications.

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "outputDirectory": "reports/junit",
     "outputName": "js-test-results.xml"
   },
-  "types": "index.d.ts",
   "files": [
     "!template/node_modules",
     "!template/package-lock.json",

--- a/tvos-types.d.ts
+++ b/tvos-types.d.ts
@@ -1,9 +1,9 @@
-import '@types/react-native';
+import 'react-native';
 
 declare module 'react-native' {
   import React from 'react';
 
-  import { ViewProps, ScrollViewProps } from '@types/react-native';
+  import { ViewProps, ScrollViewProps } from 'react-native';
 
   export const useTVEventHandler: (handleEvent: (event: HWKeyEvent) => void) => void;
 


### PR DESCRIPTION
## Summary

Continuation and fix of #102 

## Changelog

[General] [Fixed] - Working typescript extension

## Test Plan

Run `yarn tsc` after following guide in `README.md`
