### PR TITLE
fix: included the tvos-types.d in the package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,8 @@
     "scripts/react-native-xcode.sh",
     "template.config.js",
     "template",
-    "third-party-podspecs"
+    "third-party-podspecs",
+    "tvos-types.d"
   ],
   "scripts": {
     "start": "react-native start",


### PR DESCRIPTION
## Summary

#102 and #119 PRs added the TypeScript definitions, but the `tvos-types.d` file is not included in the `package.json` and therefore missing after the package installation. This fix includes the `tvos-types.d` in the `files` section of the `package.json`.

## Changelog

[General] [Fixed] - Included the `tvos-types.d` in the `files` section of the `package.json`.

## Test Plan

- Install the package `"react-native": "npm:react-native-tvos@latest"`.
- The `tvos-types.d` should be included in the `node_modules/reat-native` directory.